### PR TITLE
updated validating against eXist-db XQuery engine

### DIFF
--- a/src/main/xar-resources/data/oxygen/oxygen.xml
+++ b/src/main/xar-resources/data/oxygen/oxygen.xml
@@ -103,8 +103,7 @@
       numerous advantages in configuring oXygen to use eXist-db for validation. The steps to complete this configuration are very easy:</para>
     <orderedlist>
       <listitem>
-        <para>In oXygen, go to <guimenuitem>Preferences, XQuery</guimenuitem>. On the dropdown menu labeled, <guimenuitem>XQuery Validate
-            with</guimenuitem>, select the name of the Data Connection that you created above.</para>
+        <para>In oXygen, go to <guimenuitem>Preferences</guimenuitem> and in the window that appears select <guimenuitem>XML > XSLT-XQuery > XQuery</guimenuitem>. On the dropdown menu on the right labeled, <guimenuitem>Validation engine:</guimenuitem>, select the name of the Data Connection that you created above.</para>
       </listitem>
     </orderedlist>
     <para>Now when you are editing an XQuery file in oXygen, the validation information you receive (for instance when you click on the


### PR DESCRIPTION
The Preferences dialogue has changed within latest version of Oxygen and the steps were incorrect concerning setting up validation against the eXist-db engine